### PR TITLE
break out git repo url into config

### DIFF
--- a/mootlib/embeddings/embedding_utils.py
+++ b/mootlib/embeddings/embedding_utils.py
@@ -10,6 +10,7 @@ from openai import OpenAI
 from tqdm import tqdm
 
 from mootlib.embeddings.remote_cache import get_remote_cache
+from mootlib.utils.config import get_release_file_url
 
 model = "BAAI/bge-m3"
 EMBEDDING_DIM = 1024  # BGE-M3 embedding dimension
@@ -32,8 +33,6 @@ def compute_string_hash(text: str) -> str:
 
 class EmbeddingsCache:
     """Cache for embeddings."""
-
-    GITHUB_RELEASE_URL = "https://github.com/vigji/mootlib/releases/download/latest/embeddings.parquet.encrypted"
 
     def __init__(
         self,
@@ -69,8 +68,9 @@ class EmbeddingsCache:
         if self.cache_path.exists():
             self.cache_df = pd.read_parquet(self.cache_path)
         elif use_remote:
-            print(f"Fetching remote cache from {self.GITHUB_RELEASE_URL}")
-            self.cache_df = get_remote_cache(self.GITHUB_RELEASE_URL)
+            release_url = get_release_file_url("embeddings.parquet.encrypted")
+            print(f"Fetching remote cache from {release_url}")
+            self.cache_df = get_remote_cache(release_url)
             if self.cache_df is not None:
                 self.save_cache()
 
@@ -170,6 +170,7 @@ if __name__ == "__main__":
     from pathlib import Path
     from time import time
 
+    from mootlib.utils.config import get_release_file_url
     from mootlib.utils.encryption import decrypt_to_df
 
     # Load encrypted data

--- a/mootlib/embeddings/question_matcher.py
+++ b/mootlib/embeddings/question_matcher.py
@@ -36,6 +36,7 @@ import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 
 from mootlib.embeddings.embedding_utils import EmbeddingsCache
+from mootlib.utils.config import get_release_file_url
 from mootlib.utils.encryption import decrypt_to_df
 
 
@@ -116,7 +117,6 @@ class MootlibMatcher:
         for decrypting market data.
     """
 
-    GITHUB_RELEASE_URL = "https://github.com/vigji/mootlib/releases/download/latest/markets.parquet.encrypted"
     TEMP_DIR = Path(tempfile.gettempdir()) / "mootlib"
 
     def __init__(
@@ -186,11 +186,12 @@ class MootlibMatcher:
 
     def _download_markets_file(self) -> None:
         """Download the markets file from GitHub releases."""
+        release_url = get_release_file_url("markets.parquet.encrypted")
         print(
-            f"Downloading markets file from {self.GITHUB_RELEASE_URL} to"
+            f"Downloading markets file from {release_url} to"
             f" {self.markets_file}"
         )
-        urllib.request.urlretrieve(self.GITHUB_RELEASE_URL, self.markets_file)
+        urllib.request.urlretrieve(release_url, self.markets_file)
 
     def _is_cache_valid(self) -> bool:
         """Check if the cached file is still valid."""

--- a/mootlib/utils/config.py
+++ b/mootlib/utils/config.py
@@ -1,0 +1,107 @@
+"""Configuration utilities for Mootlib."""
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional, Final
+
+DEFAULT_GIT_REPO: Final[str] = "https://github.com/vigji/mootlib"
+
+def get_github_repo_url() -> str:
+    """Get the GitHub repository URL from environment or auto-detection.
+
+    This function checks for the repository URL in the following order:
+    1. MOOTLIB_GITHUB_REPO environment variable (full URL)
+    2. Auto-detection from git remote origin
+    3. Fallback to default repository
+
+    Returns:
+        The base GitHub repository URL (e.g., "https://github.com/user/repo")
+
+    Examples:
+        >>> # With environment variable set
+        >>> os.environ["MOOTLIB_GITHUB_REPO"] = "https://github.com/myuser/mootlib"
+        >>> get_github_repo_url()
+        'https://github.com/myuser/mootlib'
+
+        >>> # Auto-detection from git remote
+        >>> get_github_repo_url()  # detects from current repo
+        'https://github.com/vigji/mootlib'
+    """
+    # First, check if explicitly set in environment
+    if repo_url := os.getenv("MOOTLIB_GITHUB_REPO"):
+        return repo_url.rstrip("/")
+
+    # Try to auto-detect from git remote
+    try:
+        repo_url = _get_git_remote_url()
+        if repo_url:
+            return repo_url
+    except Exception:
+        # If git detection fails, continue to fallback
+        pass
+
+    # Fallback to default repository
+    return DEFAULT_GIT_REPO
+
+
+def _get_git_remote_url() -> Optional[str]:
+    """Get the GitHub repository URL from git remote origin.
+
+    Returns:
+        The GitHub repository URL if found, None otherwise.
+    """
+    try:
+        # Try to get the remote origin URL
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=Path(__file__).parent.parent.parent,  # mootlib root directory
+        )
+
+        remote_url = result.stdout.strip()
+
+        # Convert various Git URL formats to HTTPS GitHub URLs
+        if "github.com" in remote_url:
+            # Handle SSH format: git@github.com:user/repo.git
+            if remote_url.startswith("git@github.com:"):
+                repo_path = remote_url.replace("git@github.com:", "").replace(".git", "")
+                return f"https://github.com/{repo_path}"
+
+            # Handle HTTPS format: https://github.com/user/repo.git
+            elif remote_url.startswith("https://github.com/"):
+                return remote_url.replace(".git", "").rstrip("/")
+
+        return None
+
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def get_release_file_url(filename: str) -> str:
+    """Get the full URL for a release file.
+
+    Args:
+        filename: The name of the file to download (e.g., "markets.parquet.encrypted")
+
+    Returns:
+        The full URL to download the file from GitHub releases.
+
+    Examples:
+        >>> get_release_file_url("markets.parquet.encrypted")
+        'https://github.com/vigji/mootlib/releases/download/latest/markets.parquet.encrypted'
+
+        >>> get_release_file_url("embeddings.parquet.encrypted")
+        'https://github.com/vigji/mootlib/releases/download/latest/embeddings.parquet.encrypted'
+    """
+    base_url = get_github_repo_url()
+    return f"{base_url}/releases/download/latest/{filename}"
+
+
+if __name__ == "__main__":
+    # Test the configuration detection
+    print("GitHub Repository URL:", get_github_repo_url())
+    print("Markets file URL:", get_release_file_url("markets.parquet.encrypted"))
+    print("Embeddings file URL:", get_release_file_url("embeddings.parquet.encrypted"))

--- a/mootlib/utils/config.py
+++ b/mootlib/utils/config.py
@@ -3,9 +3,10 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional, Final
+from typing import Final
 
 DEFAULT_GIT_REPO: Final[str] = "https://github.com/vigji/mootlib"
+
 
 def get_github_repo_url() -> str:
     """Get the GitHub repository URL from environment or auto-detection.
@@ -45,7 +46,7 @@ def get_github_repo_url() -> str:
     return DEFAULT_GIT_REPO
 
 
-def _get_git_remote_url() -> Optional[str]:
+def _get_git_remote_url() -> str | None:
     """Get the GitHub repository URL from git remote origin.
 
     Returns:
@@ -67,7 +68,9 @@ def _get_git_remote_url() -> Optional[str]:
         if "github.com" in remote_url:
             # Handle SSH format: git@github.com:user/repo.git
             if remote_url.startswith("git@github.com:"):
-                repo_path = remote_url.replace("git@github.com:", "").replace(".git", "")
+                repo_path = remote_url.replace("git@github.com:", "").replace(
+                    ".git", ""
+                )
                 return f"https://github.com/{repo_path}"
 
             # Handle HTTPS format: https://github.com/user/repo.git


### PR DESCRIPTION
Currently the git repo for the encrypted files is hardcoded to `https://github.com/vigji/mootlib`, I'm changing this to allow for this to be set by envvars, .env, or the current `.git` repo. 

Let me know if this looks like a good approach, especially considering this is the first instance of a "config" module and there may be differing opinions on where this belongs, its structure, and the order of configuration value fetch preference.  Especially introspecting the `.git` repo may not work right if this is a library or something

Majority of code was generated by Claude 4 using zed agent.